### PR TITLE
(SIMP-413) Use /etc/sysctl.d dir for config

### DIFF
--- a/build/pupmod-sysctl.spec
+++ b/build/pupmod-sysctl.spec
@@ -1,7 +1,7 @@
 Summary: Sysctl Puppet Module
 Name: pupmod-sysctl
 Version: 4.1.0
-Release: 3
+Release: 4
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -55,6 +55,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Sep 2 2015 Nick Miller <nick.miller@onyxpoint.com> - 4.1.0-4
+- Moved the configuration file from /etc/sysctl.conf to /etc/sysctl.d/20-simp.conf
+  to avoid conflict with packages
+
 * Wed Feb 18 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-4
 - Updated to use new simp environment
 - Now use the augeasprovider sysctl native type for managing sysctl entries.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 #
 class sysctl {
 
-    file { '/etc/sysctl.conf':
+    file { '/etc/sysctl.d/20-simp.conf':
         ensure => 'present',
         owner  => 'root',
         group  => 'root',

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -23,7 +23,7 @@ define sysctl::value(
       default => 'present'
     },
     val     => $value,
-    require => File['/etc/sysctl.conf']
+    require => File['/etc/sysctl.d/20-simp.conf']
   }
 
   if "$value" != 'nil' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,7 +5,7 @@ describe 'sysctl' do
   it { should create_class('sysctl') }
 
   it do
-    should contain_file('/etc/sysctl.conf').with({
+    should contain_file('/etc/sysctl.d/20-simp.conf').with({
       'ensure' => 'present',
       'owner' => 'root',
       'group' => 'root',

--- a/spec/defines/set_value_spec.rb
+++ b/spec/defines/set_value_spec.rb
@@ -10,7 +10,7 @@ describe 'sysctl::set_value' do
     should contain_sysctl('net.unix.max_dgram_qlen').with({
       'ensure' => 'present',
       'val' => '50',
-      'require' => 'File[/etc/sysctl.conf]'
+      'require' => 'File[/etc/sysctl.d/20-simp.conf]'
     })
   end
 
@@ -28,7 +28,7 @@ describe 'sysctl::set_value' do
       should contain_sysctl('net.unix.max_dgram_qlen').with({
         'ensure' => 'absent',
         'val' => 'nil',
-        'require' => 'File[/etc/sysctl.conf]'
+        'require' => 'File[/etc/sysctl.d/20-simp.conf]'
       })
     end
   end


### PR DESCRIPTION
Moved the configuration file from /etc/sysctl.conf to
/etc/sysctl.d/20-simp.conf to avoid conflicts with packages.

SIMP-413 #close
