### PR TITLE
(SIMP-456) Ensure /etc/sysctl.d exists

### DIFF
--- a/build/pupmod-sysctl.spec
+++ b/build/pupmod-sysctl.spec
@@ -1,7 +1,7 @@
 Summary: Sysctl Puppet Module
 Name: pupmod-sysctl
 Version: 4.1.0
-Release: 4
+Release: 5
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -55,9 +55,9 @@ fi
 # Post uninstall stuff
 
 %changelog
-* Wed Sep 2 2015 Nick Miller <nick.miller@onyxpoint.com> - 4.1.0-4
+* Wed Sep 2 2015 Nick Miller <nick.miller@onyxpoint.com> - 4.1.0-5
 - Moved the configuration file from /etc/sysctl.conf to /etc/sysctl.d/20-simp.conf
-  to avoid conflict with packages
+  to avoid conflict with packages.
 
 * Wed Feb 18 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-4
 - Updated to use new simp environment

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,10 +10,18 @@
 #
 class sysctl {
 
-    file { '/etc/sysctl.d/20-simp.conf':
-        ensure => 'present',
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0600',
-    }
+  file { '/etc/sysctl.d/':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755'
+  }
+
+  file { '/etc/sysctl.d/20-simp.conf':
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0600',
+    require => File['/etc/sysctl.d/']
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,11 +5,21 @@ describe 'sysctl' do
   it { should create_class('sysctl') }
 
   it do
+    should contain_file('/etc/sysctl.d/').with({
+      'ensure' => 'directory',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0755',
+    })
+  end
+
+  it do
     should contain_file('/etc/sysctl.d/20-simp.conf').with({
-      'ensure' => 'present',
-      'owner' => 'root',
-      'group' => 'root',
-      'mode' => '0600'
+      'ensure'  => 'present',
+      'owner'   => 'root',
+      'group'   => 'root',
+      'mode'    => '0600',
+      'require' => 'File[/etc/sysctl.d/]'
     })
   end
 


### PR DESCRIPTION
SIMP-413 modified sysctl to use /etc/sysctl.d/20-simp.conf by default,
but never ensured /etc/sysctl.d was present.

SIMP-456 #close Ensure /etc/sysctl.d exists
