### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@
 fixtures:
   repositories:
     common: "git://github.com/simp/pupmod-simp-common"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
     augeasproviders : "git://github.com/simp/augeasproviders"
     augeasproviders_core : "git://github.com/simp/augeasproviders_core"

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -3,4 +3,5 @@ fixtures:
   symlinks:
     sysctl: "#{source_dir}"
     common: "#{source_dir}/../common"
+    simplib: "#{source_dir}/../simplib"
     stdlib: "#{source_dir}/../stdlib"

--- a/build/pupmod-sysctl.spec
+++ b/build/pupmod-sysctl.spec
@@ -137,6 +137,6 @@ fi
 - Capabilites were included to ensure that existing double quoted values will
   continue to function properly.
 
-* Thu Nov 02 2009 Maintenance
+* Mon Nov 02 2009 Maintenance
 0.1-6
 - Simple change from require to subscribe.


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-sysctl`.
SIMP-604 #comment Updated `pupmod-simp-sysctl`.
