### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,5 @@
-Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0
-Provides: pupmod-puppet-sysctl
 Obsoletes: pupmod-puppet-sysctl >= 0.0.1
 Obsoletes: pupmod-sysctl-test >= 0.0.1
+Provides: pupmod-puppet-sysctl
+Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,17 +1,20 @@
 {
-  "name":    "simp-sysctl",
-  "version": "4.2.0",
-  "author":  "simp",
+  "name": "simp-sysctl",
+  "version": "4.2.1",
+  "author": "simp",
   "summary": "Manages sysctl - Deprecated use augeasproviders_sysctl",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-sysctl",
+  "source": "https://github.com/simp/pupmod-simp-sysctl",
   "project_page": "https://github.com/simp/pupmod-simp-sysctl",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "sysctl" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "sysctl"
+  ],
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">= 2.1.0"
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-sysctl`
SIMP-1635 #close
